### PR TITLE
fix: prevent duplicate UAnalyze report notifications

### DIFF
--- a/analysis_bot/services/uanalyze_monitor.py
+++ b/analysis_bot/services/uanalyze_monitor.py
@@ -1,5 +1,6 @@
 """UAnalyze 報告監控服務：定時抓取新報告並推播 Telegram。"""
 
+import asyncio
 import html
 import json
 import logging
@@ -13,7 +14,8 @@ from .http import create_session
 
 logger = logging.getLogger(__name__)
 
-STATE_FILE = Path("data/uanalyze/last_seen_id.json")
+STATE_FILE = Path(__file__).parent.parent.parent / "data" / "uanalyze" / "last_seen_id.json"
+_CHECK_LOCK = asyncio.Lock()
 
 
 def _load_last_id() -> int:
@@ -67,6 +69,14 @@ def _format_report(report: dict, index: int, total: int, keywords: list[str]) ->
 
 async def check_new_reports(bot=None, dry_run: bool = False) -> int:
     """Check for new reports and send to Telegram. Returns count of new reports."""
+    if _CHECK_LOCK.locked():
+        logger.info("UAnalyze monitor: previous run still in progress, skipping")
+        return 0
+    async with _CHECK_LOCK:
+        return await _do_check_new_reports(bot=bot, dry_run=dry_run)
+
+
+async def _do_check_new_reports(bot=None, dry_run: bool = False) -> int:
     settings = get_settings()
     api_url = settings.UANALYZE_API_URL
     if not api_url:
@@ -106,8 +116,9 @@ async def check_new_reports(bot=None, dry_run: bool = False) -> int:
 
     logger.info("UAnalyze: %d new reports", len(new_reports))
 
+    sent = 0
+    total = len(new_reports)
     if not dry_run and bot and chat_id:
-        total = len(new_reports)
         for i, report in enumerate(new_reports, 1):
             text, has_kw = _format_report(report, i, total, keywords)
             kwargs = {"chat_id": chat_id, "text": text, "parse_mode": "HTML", "disable_notification": not has_kw}
@@ -115,11 +126,14 @@ async def check_new_reports(bot=None, dry_run: bool = False) -> int:
                 kwargs["message_thread_id"] = topic_id
             try:
                 await bot.send_message(**kwargs)
+                _save_last_id(report["id"])
+                sent += 1
             except Exception as e:
                 logger.error("UAnalyze telegram send error: %s", e)
             if i < total:
-                import asyncio
                 await asyncio.sleep(0.3)
+    else:
+        _save_last_id(max(r["id"] for r in new_reports))
+        sent = total
 
-    _save_last_id(max(r["id"] for r in new_reports))
-    return len(new_reports)
+    return sent


### PR DESCRIPTION
- Use absolute STATE_FILE path anchored to module location to avoid CWD issues
- Add asyncio.Lock to skip concurrent scheduler runs
- Save last_id after each successful send instead of batching at end